### PR TITLE
Little endian (discover only)

### DIFF
--- a/src/lib/io/IO_Misc.f90
+++ b/src/lib/io/IO_Misc.f90
@@ -349,7 +349,7 @@ CONTAINS
     REAL, DIMENSION(nlat,nlon)        :: xdummy
     REAL, DIMENSION(:,:,:)            :: Arr
     iu=get_lun()
-    OPEN(iu,FILE=NWPFile,FORM='UNFORMATTED',ACCESS='DIRECT',RECL=nlon*nlat*4)
+    OPEN(iu,FILE=NWPFile,FORM='UNFORMATTED',ACCESS='DIRECT',RECL=nlon*nlat*4,CONVERT='LITTLE_ENDIAN')
     DO irec=1,nparam
         read(iu,rec=irec) xdummy
         Arr(:,:,irec) = xdummy(:,:)


### PR DESCRIPTION
I added the Little_Endian fix to be able to read GFS files. 
We need to mention somewhere that we need CRTM Little Endian coefficients copied to data directory 